### PR TITLE
feat(dart_frog): add tryRead method to RequestContext

### DIFF
--- a/docs/docs/basics/dependency-injection.md
+++ b/docs/docs/basics/dependency-injection.md
@@ -34,6 +34,17 @@ Response onRequest(RequestContext context) {
 }
 ```
 
+If you want to attempt to `read` a value that has not been provided, it will throw a `StateError`. However, if you want to _attempt_ to `read` a value whether it's provided or not, you can use `context.tryRead<T>()`. If no value matching that time has been provided, it will return `null`.
+
+```dart
+import 'package:dart_frog/dart_frog.dart';
+
+Response onRequest(RequestContext context) {
+  final greeting = context.tryRead<String>();
+  return Response(body: greeting ?? 'Default Greeting');
+}
+```
+
 ### Extracting Providers
 
 In the above example, we defined the `provider` inline. This is fine for simple cases, but for more complex providers or providers which you want to reuse, it can be helpful to extract the provider to its own file:

--- a/packages/dart_frog/lib/src/context.dart
+++ b/packages/dart_frog/lib/src/context.dart
@@ -43,6 +43,21 @@ This can happen if $T was not provided to the request context:
     return (value as T Function())();
   }
 
+  /// Attempt to lookup an instance of [T] from the [request] context.
+  ///
+  /// Returns `null` if [T] is not available within the provided
+  /// [request] context.
+  T? tryRead<T>() {
+    try {
+      return read<T>();
+      // Explicitly catching [StateError] as it's what it throw
+      // when [read] fails
+      // ignore: avoid_catching_errors
+    } on StateError catch (_) {
+      return null;
+    }
+  }
+
   /// Get URL parameters captured by the [Router.mount].
   /// They can be accessed from inside the mounted routes.
   Map<String, String> get mountedParams {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Closes #1651. Adds a `tryRead` function to the `RequestContext` that works exactly like `read`, but instead of throwing a `StateError` when a provided value isn't found, it return `null`. This is useful for objects that may or not be provided depending on certain factors, like a `User` being provided only if they are authenticated. The change has also been reflected in the docs site.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
